### PR TITLE
By running export GAZEBO_MODEL_PATH=`pwd`:$GAZEBO_MODEL_PATH ...

### DIFF
--- a/database.config
+++ b/database.config
@@ -1,0 +1,11 @@
+<?xml version='1.0'?>
+<database>
+<name>iCub Gazebo Database</name>
+<license>Creative Commons Attribution 3.0 Unported</license>
+<models>
+<uri>file://icub</uri>
+<uri>file://icub_feet_fixed</uri>
+<uri>file://icub_fixed</uri>
+<uri>file://icub_legs</uri>
+</models>
+</database>


### PR DESCRIPTION
... in the main icub_gazebo folder you will now have all the iCub models available in gazebo.
Useful for integration in the robotology superbuild
