### PR TITLE
Controlboard verbose flag is off by default

### DIFF
--- a/icub/conf/gazebo_icub_head.ini
+++ b/icub/conf/gazebo_icub_head.ini
@@ -14,7 +14,7 @@ networks ( head )
 # for each network specify the joint map
 head  0 2 0 2
 # Verbose output (on if present, off if commented out)
-verbose
+#verbose
 
 # Specify configuration of MotorControl devices
 [head]

--- a/icub/conf/gazebo_icub_left_arm.ini
+++ b/icub/conf/gazebo_icub_left_arm.ini
@@ -14,7 +14,7 @@ networks ( left_arm )
 # for each network specify the joint map
 left_arm  0 6 0 6
 # Verbose output (on if present, off if commented out)
-verbose
+#verbose
 
 
 # Specify configuration of MotorControl devices

--- a/icub/conf/gazebo_icub_left_leg.ini
+++ b/icub/conf/gazebo_icub_left_leg.ini
@@ -14,7 +14,7 @@ networks ( left_leg )
 # for each network specify the joint map
 left_leg  0 5 0 5
 # Verbose output (on if present, off if commented out)
-verbose
+#verbose
 
 
 # Specify configuration of MotorControl devices

--- a/icub/conf/gazebo_icub_right_arm.ini
+++ b/icub/conf/gazebo_icub_right_arm.ini
@@ -14,7 +14,7 @@ networks ( right_arm )
 # for each network specify the joint map
 right_arm  0 6 0 6
 # Verbose output (on if present, off if commented out)
-verbose
+#verbose
 
 
 # Specify configuration of MotorControl devices

--- a/icub/conf/gazebo_icub_right_leg.ini
+++ b/icub/conf/gazebo_icub_right_leg.ini
@@ -15,7 +15,7 @@ networks ( right_leg )
 # for each network specify the joint map
 right_leg  0 5 0 5
 # Verbose output (on if present, off if commented out)
-verbose
+#verbose
 
 
 # Specify configuration of MotorControl devices

--- a/icub/conf/gazebo_icub_torso.ini
+++ b/icub/conf/gazebo_icub_torso.ini
@@ -14,7 +14,7 @@ networks ( torso )
 # for each network specify the joint map
 torso  0 2 0 2
 # Verbose output (on if present, off if commented out)
-verbose
+#verbose
 
 # Specify configuration of MotorControl devices
 [torso]

--- a/icub_legs/conf/gazebo_icub_left_leg.ini
+++ b/icub_legs/conf/gazebo_icub_left_leg.ini
@@ -14,7 +14,7 @@ networks ( left_leg )
 # for each network specify the joint map
 left_leg  0 5 0 5
 # Verbose output (on if present, off if commented out)
-verbose
+#verbose
 
 
 # Specify configuration of MotorControl devices

--- a/icub_legs/conf/gazebo_icub_right_leg.ini
+++ b/icub_legs/conf/gazebo_icub_right_leg.ini
@@ -14,7 +14,7 @@ networks ( right_leg )
 # for each network specify the joint map
 right_leg  0 5 0 5
 # Verbose output (on if present, off if commented out)
-verbose
+#verbose
 
 
 # Specify configuration of MotorControl devices


### PR DESCRIPTION
I think it is better to leave the `verbose` flag off by default otherwise there are too many prints in the terminal, slowing down the whole gazebo process.
