### PR TITLE
Fix icub controlboard name

### DIFF
--- a/icub/icub.sdf
+++ b/icub/icub.sdf
@@ -2159,11 +2159,11 @@
     <plugin name='controlboard_head' filename='libgazebo_yarp_controlboard.so'>
       <yarpConfigurationFile>model://icub/conf/gazebo_icub_head.ini</yarpConfigurationFile>
     </plugin>
-    <plugin name='controlboard_left_arm_no_arm' filename='libgazebo_yarp_controlboard.so'>
+    <plugin name='controlboard_left_arm_no_hand' filename='libgazebo_yarp_controlboard.so'>
       <yarpConfigurationFile>model://icub/conf/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini</yarpConfigurationFile>
       <initialConfiguration>-0.52 0.52 0 0.785 0 0 0.698</initialConfiguration>
     </plugin>
-    <plugin name='controlboard_right_arm_no_arm' filename='libgazebo_yarp_controlboard.so'>
+    <plugin name='controlboard_right_arm_no_hand' filename='libgazebo_yarp_controlboard.so'>
       <yarpConfigurationFile>model://icub/conf/gazebo_icub_right_arm_no_hand_for_no_hand_model.ini</yarpConfigurationFile>
       <initialConfiguration>-0.52 0.52 0 0.785 0 0 0.698</initialConfiguration>
     </plugin>


### PR DESCRIPTION
The name of the control boards in the arms of the [`icub.sdf`](https://github.com/robotology/icub-gazebo/blob/master/icub/icub.sdf) (model without the hand) have a typo error, they are called `controlboard_x_arm_no_arm` while they are meant to control the arm without hand (`_no_hand` as in [`icub_with_hands`](https://github.com/robotology/icub-gazebo/blob/master/icub_with_hands/icub_with_hands.sdf)). This typo error was never noticed since the `name` of `yarpGazeboControlBoard` plugin has never been used in the past.

Since now we are going to start using that name (see https://github.com/robotology/icub-gazebo-wholebody/commit/c09724a96815a85d24e400325757ccfc8519569b), I think is time to fix it. It should not cause any back-compatibility problem since that name is never used a part from https://github.com/robotology/icub-gazebo-wholebody/tree/devel where it can be easily updated.