### PR TITLE
Fixes wrong axis directions of joints {left, right}_eye_link

### DIFF
--- a/icub/icub.sdf
+++ b/icub/icub.sdf
@@ -1719,7 +1719,7 @@
       <child>left_eye_link</child>
       <parent>eyes_tilt_link</parent>
       <axis>
-        <xyz>0.0 0.0 1.0</xyz>
+        <xyz>0.0 0.0 -1.0</xyz>
         <limit>
           <lower>-1.5708</lower>
           <upper>1.5708</upper>
@@ -1750,7 +1750,7 @@
       <child>right_eye_link</child>
       <parent>eyes_tilt_link</parent>
       <axis>
-        <xyz>0.0 0.0 1.0</xyz>
+        <xyz>0.0 0.0 -1.0</xyz>
         <limit>
           <lower>-1.5708</lower>
           <upper>1.5708</upper>

--- a/icub_with_hands/icub_with_hands.sdf
+++ b/icub_with_hands/icub_with_hands.sdf
@@ -876,7 +876,7 @@
       <child>left_eye_link</child>
       <parent>eyes_tilt_link</parent>
       <axis>
-        <xyz>0.0 0.0 1.0</xyz>
+        <xyz>0.0 0.0 -1.0</xyz>
         <limit>
           <lower>-1.5708</lower>
           <upper>1.5708</upper>
@@ -907,7 +907,7 @@
       <child>right_eye_link</child>
       <parent>eyes_tilt_link</parent>
       <axis>
-        <xyz>0.0 0.0 1.0</xyz>
+        <xyz>0.0 0.0 -1.0</xyz>
         <limit>
           <lower>-1.5708</lower>
           <upper>1.5708</upper>


### PR DESCRIPTION
This PR fixes wrong axis directions of joints `{left, right}_eye_link` of robots `icub` and `icub_with_hands`. The robot `icub_fixed` is automatically handled as it is constructed from `icub`.

Fixes #68 