### PR TITLE
Switch controlboard plugins to set velocityControlImplementationType to integrator_and_position_pid

### DIFF
--- a/icub/conf/gazebo_icub_head.ini
+++ b/icub/conf/gazebo_icub_head.ini
@@ -51,6 +51,7 @@ stictionUp    0.0   0.0   0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 4.363 4.363 4.363

--- a/icub/conf/gazebo_icub_left_arm_no_hand.ini
+++ b/icub/conf/gazebo_icub_left_arm_no_hand.ini
@@ -49,6 +49,7 @@ stictionUp    0.0   0.0   0.0   0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 5.236 5.236 5.236 5.236

--- a/icub/conf/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini
+++ b/icub/conf/gazebo_icub_left_arm_no_hand_for_no_hand_model.ini
@@ -49,6 +49,7 @@ stictionUp    0.0   0.0   0.0   0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 5.236 5.236 5.236 5.236

--- a/icub/conf/gazebo_icub_left_hand_finger.ini
+++ b/icub/conf/gazebo_icub_left_hand_finger.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 5.235

--- a/icub/conf/gazebo_icub_left_hand_fingers.ini
+++ b/icub/conf/gazebo_icub_left_hand_fingers.ini
@@ -59,6 +59,7 @@ stictionUp    0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   
 stictionDwn   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236

--- a/icub/conf/gazebo_icub_left_hand_index.ini
+++ b/icub/conf/gazebo_icub_left_hand_index.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726

--- a/icub/conf/gazebo_icub_left_hand_middle.ini
+++ b/icub/conf/gazebo_icub_left_hand_middle.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726

--- a/icub/conf/gazebo_icub_left_hand_pinky.ini
+++ b/icub/conf/gazebo_icub_left_hand_pinky.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 8.726 8.726 8.726

--- a/icub/conf/gazebo_icub_left_hand_thumb.ini
+++ b/icub/conf/gazebo_icub_left_hand_thumb.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 5.236

--- a/icub/conf/gazebo_icub_left_leg.ini
+++ b/icub/conf/gazebo_icub_left_leg.ini
@@ -48,6 +48,7 @@ stictionUp    0.0    0.0    0.0    0.0    0.0    0.0
 stictionDwn   0.0    0.0    0.0    0.0    0.0    0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 8.726 8.726 8.726

--- a/icub/conf/gazebo_icub_right_arm_no_hand.ini
+++ b/icub/conf/gazebo_icub_right_arm_no_hand.ini
@@ -49,6 +49,7 @@ stictionUp    0.0   0.0   0.0   0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 5.236 5.236 5.236 5.236

--- a/icub/conf/gazebo_icub_right_arm_no_hand_for_no_hand_model.ini
+++ b/icub/conf/gazebo_icub_right_arm_no_hand_for_no_hand_model.ini
@@ -49,6 +49,7 @@ stictionUp    0.0   0.0   0.0   0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 5.236 5.236 5.236 5.236

--- a/icub/conf/gazebo_icub_right_hand_finger.ini
+++ b/icub/conf/gazebo_icub_right_hand_finger.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 5.236

--- a/icub/conf/gazebo_icub_right_hand_fingers.ini
+++ b/icub/conf/gazebo_icub_right_hand_fingers.ini
@@ -59,6 +59,7 @@ stictionUp    0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   
 stictionDwn   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236 5.236

--- a/icub/conf/gazebo_icub_right_hand_index.ini
+++ b/icub/conf/gazebo_icub_right_hand_index.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726

--- a/icub/conf/gazebo_icub_right_hand_middle.ini
+++ b/icub/conf/gazebo_icub_right_hand_middle.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726

--- a/icub/conf/gazebo_icub_right_hand_pinky.ini
+++ b/icub/conf/gazebo_icub_right_hand_pinky.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 8.726 8.726 8.726

--- a/icub/conf/gazebo_icub_right_hand_thumb.ini
+++ b/icub/conf/gazebo_icub_right_hand_thumb.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 5.236

--- a/icub/conf/gazebo_icub_right_leg.ini
+++ b/icub/conf/gazebo_icub_right_leg.ini
@@ -48,6 +48,7 @@ stictionUp    0.0    0.0    0.0    0.0    0.0    0.0
 stictionDwn   0.0    0.0    0.0    0.0    0.0    0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 8.726 8.726 8.726

--- a/icub/conf/gazebo_icub_torso.ini
+++ b/icub/conf/gazebo_icub_torso.ini
@@ -48,6 +48,7 @@ stictionUp    0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726


### PR DESCRIPTION
This change is ignored for versions of gazebo-yarp-plugins <= 3.5.0, but for version of gazebo-yarp-plugins > 3.5.0 it aligns the behavior of the VOCAB_CM_VELOCITY control mode with the one of the real iCub robot.

Related issues:
 * https://github.com/robotology/gazebo-yarp-plugins/pull/514
 * https://github.com/robotology/gazebo-yarp-plugins/issues/240