### PR TITLE
Add a deprecation note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 icub-gazebo
 ===========
 
-**This repository hosted for a long time some manually assembled models to simulate the iCub humanoid robot in Gazebo. Being manually modified, the model contained in this repo are deprecated, and all users interested in simulating the iCub in Gazebo should use the model provided in https://github.com/robotology/icub-models instead. See https://github.com/robotology/robotology-superbuild/issues/542 for more details.**
+**This repository hosted for a long time some manually assembled models to simulate the iCub humanoid robot in Gazebo. Being manually modified, the model contained in this repo are deprecated, and all users interested in simulating the iCub in Gazebo should use the model provided in https://github.com/robotology/icub-models instead. See https://github.com/robotology/robotology-superbuild/issues/542 for more details. A detailed example of using the models provided in icub-models for grasping can be found in https://github.com/robotology/icub-gazebo-grasping-sandbox.**
 
 
 Preliminary files for simulation of the iCub humanoid robot in Gazebo (meshes courtesy of Joseph Salini - UPMC). Note that these models are compatible only with the Gazebo versions that use SDF 1.5 or higher. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 icub-gazebo
 ===========
 
+**This repository hosted for a long time some manually assembled models to simulate the iCub humanoid robot in Gazebo. Being manually modified, the model contained in this repo are deprecated, and all users interested in simulating the iCub in Gazebo should use the model provided in https://github.com/robotology/icub-models instead. See https://github.com/robotology/robotology-superbuild/issues/542 for more details.**
+
+
 Preliminary files for simulation of the iCub humanoid robot in Gazebo (meshes courtesy of Joseph Salini - UPMC). Note that these models are compatible only with the Gazebo versions that use SDF 1.5 or higher. 
 
 Installation


### PR DESCRIPTION
As discussed in https://github.com/robotology/robotology-superbuild/issues/542, this repo will not be updated anymore and almost all its functionalities are available in icub-models, so it is better to clarify this to the users.